### PR TITLE
ASM-3011 HyperV deployment workflow with two nic ASM appliance

### DIFF
--- a/tasks/windows2012.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2012.task/hyper-v-unattended.xml.erb
@@ -95,14 +95,14 @@
       <RunSynchronousCommand wcm:action="add">
         <Description>Add to Hosts file</Description>
         <Order>1</Order>
-        <Path>powershell.exe -Command "Add-Content \"c:\windows\system32\drivers\etc\hosts\" \"`n<%= URI.parse(repo_url).host %> dellasm\""</Path>
+        <Path>powershell.exe -Command "Add-Content \"c:\windows\system32\drivers\etc\hosts\" \"`n<%= os.puppet_master_server_ip %> dellasm\""</Path>
       </RunSynchronousCommand>
 
 <!-- Replace PUPPETSERVER with your puppet server -->
       <RunSynchronousCommand wcm:action="add">
         <Description>Install Puppet Agent from razor server</Description>
         <Order>2</Order>
-        <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= ASM::Util.hostname_to_certname(node.hostname.split('.').first) %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path> 
+        <Path>msiexec /i \\<%= os.puppet_master_server_ip %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= ASM::Util.hostname_to_certname(node.hostname.split('.').first) %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
       </RunSynchronousCommand>
 
       <RunSynchronousCommand wcm:action="add">

--- a/tasks/windows2012.task/unattended.xml.erb
+++ b/tasks/windows2012.task/unattended.xml.erb
@@ -16,7 +16,8 @@ version = DEFAULT_OS if version == '2012'
 os = OpenStruct.new
 os.version = version
 os.license = options['product_key'] || settings[windows_version]['license']
-os.puppet_master_server_ip = ASM::Util.get_preferred_ip(node['ipaddress'])
+node_ip = JSON.parse(node[:facts])['ipaddress'].gsub(/:/,'')
+os.puppet_master_server_ip = ASM::Util.get_preferred_ip(node_ip)
 
 if options['os_type'] == 'hyperv'
   content = ASM::Util.load_file('hyper-v-unattended.xml.erb', base_dir)

--- a/tasks/windows2012.task/unattended.xml.erb
+++ b/tasks/windows2012.task/unattended.xml.erb
@@ -16,7 +16,7 @@ version = DEFAULT_OS if version == '2012'
 os = OpenStruct.new
 os.version = version
 os.license = options['product_key'] || settings[windows_version]['license']
-os.puppet_master_server_ip = ASM::Util.get_preferred_puppet_master_ip(node['ipaddress'])
+os.puppet_master_server_ip = ASM::Util.get_preferred_ip(node['ipaddress'])
 
 if options['os_type'] == 'hyperv'
   content = ASM::Util.load_file('hyper-v-unattended.xml.erb', base_dir)

--- a/tasks/windows2012.task/unattended.xml.erb
+++ b/tasks/windows2012.task/unattended.xml.erb
@@ -1,7 +1,9 @@
 <%=
 require 'erb'
+require 'uri'
 require 'ostruct'
 require 'asm/util'
+require 'hashie'
 
 DEFAULT_OS = 'Windows Server 2012 SERVERSTANDARD'
 base_dir = File.join(ASM::Util::INSTALLER_OPTS_DIR, "#{task.base.name}.task")
@@ -14,6 +16,7 @@ version = DEFAULT_OS if version == '2012'
 os = OpenStruct.new
 os.version = version
 os.license = options['product_key'] || settings[windows_version]['license']
+os.puppet_master_server_ip = ASM::Util.get_preferred_puppet_master_ip(node['ipaddress'])
 
 if options['os_type'] == 'hyperv'
   content = ASM::Util.load_file('hyper-v-unattended.xml.erb', base_dir)


### PR DESCRIPTION
In case PXE network is not-routable and not accessible on the puppet master server (ASM Server) on normal management IP and second NIC on PXE network is available on the appliance, then that IP is used for communication between Puppet Master Server puppet agent.