### PR TITLE
NTP Configuration for ESXi

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -122,8 +122,8 @@ restrict default kod nomodify notrap noquerynopeer
 restrict 127.0.0.1
 server $ntp_server
 __NTP_CONFIG__
-service ntpd start
-/sbin/chkconfig --level 345 ntpd on
+/etc/init.d/ntpd restart
+/sbin/chkconfig ntpd on
 fi
 
 # enter maintenance mode


### PR DESCRIPTION
command used for starting the service and adding it to the start-up list was not correct. Old commands were applicable for ESX not ESXi and these were part of original ESXi kickstart template file.