### PR TITLE
ASM-3312 support fqdn hostnames

### DIFF
--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -66,7 +66,7 @@ cat > /etc/puppet/puppet.conf << EOF
 [agent]
     classfile   = \$vardir/classes.txt
     localconfig = \$vardir/localconfig
-    certname    = <%= require 'asm/util'; ASM::Util.hostname_to_certname(node.hostname.split('.').first) %>
+    certname    = <%= node.policy.node_metadata['installer_options']['agent_certname'] %>
 
 EOF
 

--- a/tasks/windows2008.task/default-unattended.xml.erb
+++ b/tasks/windows2008.task/default-unattended.xml.erb
@@ -73,7 +73,7 @@
         <RunSynchronousCommand wcm:action="add">
           <Description>Install Puppet Agent from razor server</Description>
           <Order>2</Order>
-          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER="dellasm" PUPPET_AGENT_CERTNAME="<%=  require 'asm/util'; ASM::Util.hostname_to_certname(node.hostname.split('.').first) %>" PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD="<%= ASM::Cipher.decrypt_string(node.root_password) %>"</Path>
+          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER="dellasm" PUPPET_AGENT_CERTNAME="<%= node.policy.node_metadata['installer_options']['agent_certname'] %>" PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD="<%= ASM::Cipher.decrypt_string(node.root_password) %>"</Path>
         </RunSynchronousCommand>
         <%=
           if os.ntp_server

--- a/tasks/windows2008.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2008.task/hyper-v-unattended.xml.erb
@@ -102,7 +102,7 @@
       <RunSynchronousCommand wcm:action="add">
         <Description>Install Puppet Agent from razor server</Description>
         <Order>2</Order>
-        <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= ASM::Util.hostname_to_certname(node.hostname.split('.').first) %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path> 
+        <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
       </RunSynchronousCommand>
 
       <RunSynchronousCommand wcm:action="add">

--- a/tasks/windows2012.task/default-unattended.xml.erb
+++ b/tasks/windows2012.task/default-unattended.xml.erb
@@ -119,7 +119,7 @@
         <RunSynchronousCommand wcm:action="add">
           <Description>Install Puppet Agent from razor server</Description>
           <Order>2</Order>
-          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%=  require 'asm/util'; ASM::Util.hostname_to_certname(node.hostname.split('.').first) %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
+          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
         </RunSynchronousCommand>
         <%=
           if os.ntp_server

--- a/tasks/windows2012.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2012.task/hyper-v-unattended.xml.erb
@@ -102,7 +102,7 @@
       <RunSynchronousCommand wcm:action="add">
         <Description>Install Puppet Agent from razor server</Description>
         <Order>2</Order>
-        <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= ASM::Util.hostname_to_certname(node.hostname.split('.').first) %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path> 
+        <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
       </RunSynchronousCommand>
 
       <RunSynchronousCommand wcm:action="add">


### PR DESCRIPTION
The razor task scripts were calculating the correct puppet agent
certificate name to use based off of the first word in the
hostname. This certificate name has to match that used in
asm-deployer in order for the correct puppet configuration to be
applied to the node. In the case where the FQDN was used as the
hostname the certificate name calculated on the razor side was
incorrect because it missed the domain name. It's not possible to
just use the fqdn when calculating the agent certificate name
because the original hostname specified by the user may not have
been an FQDN.

This commit adds agent_certname to the razor policy
installer_options. The razor task scripts use that option which
guarantees that they are using the same certificate name that
asm-deployer uses.