### PR TITLE
ASM-3272: Handle postgres failures better

### DIFF
--- a/lib/razor/initialize.rb
+++ b/lib/razor/initialize.rb
@@ -83,6 +83,10 @@ module Razor
   Razor.database
   Razor.database.extension :pg_array
 
+  # ASM local patch to work around ASM-3272 and RAZOR-70
+  Razor.database.extension :connection_validator
+  Razor.database.pool.connection_validation_timeout = 10
+
   # Ensure the migration extension is available, now that we use it as part of
   # each request to ensure that we catch missed migrations correctly.
   Sequel.extension :migration


### PR DESCRIPTION
Older versions of Sequel gems do not catch DB exceptions in the case
where the DB fails and so Razor just don't work after a DB restart
or connection interrupt.

Version 4.6.0 of Sequel has a patch to handle this better but Razor
requires 4.3.x due to some incompatibilities.

We can upgrade Sequel and it seems the Razor team has done so in
RAZOR-70 but they are only going up to 4.9 which is not a version we
have

So we can either install 4.9.0 on the appliance and carry a patch to
take us to that version Gem or apply the patch in this commit.  I think
rather than install more versions of sequel - which do not seem to come
from RPMs - this is probably the less complicated route at least until
we upgrade Razor again

This commit activates regular rechecking of the connection in Razor,
should the conection fail a few DB requests will log exceptions but
after 10 seconds it will reconnect and if that is succesfull it will
then recover