### PR TITLE
ASM-2476 Puppet agent fails on hyper-v host after configuration

### DIFF
--- a/tasks/windows2012.task/default-unattended.xml.erb
+++ b/tasks/windows2012.task/default-unattended.xml.erb
@@ -119,7 +119,7 @@
         <RunSynchronousCommand wcm:action="add">
           <Description>Install Puppet Agent from razor server</Description>
           <Order>2</Order>
-          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.4.3.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
+          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
         </RunSynchronousCommand>
         <%=
           if os.ntp_server

--- a/tasks/windows2012.task/default-unattended.xml.erb
+++ b/tasks/windows2012.task/default-unattended.xml.erb
@@ -119,7 +119,7 @@
         <RunSynchronousCommand wcm:action="add">
           <Description>Install Puppet Agent from razor server</Description>
           <Order>2</Order>
-          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
+          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.4.3.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
         </RunSynchronousCommand>
         <%=
           if os.ntp_server

--- a/tasks/windows2012.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2012.task/hyper-v-unattended.xml.erb
@@ -102,7 +102,7 @@
       <RunSynchronousCommand wcm:action="add">
         <Description>Install Puppet Agent from razor server</Description>
         <Order>2</Order>
-        <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
+        <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.4.3.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
       </RunSynchronousCommand>
 
       <RunSynchronousCommand wcm:action="add">

--- a/tasks/windows2012.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2012.task/hyper-v-unattended.xml.erb
@@ -102,7 +102,7 @@
       <RunSynchronousCommand wcm:action="add">
         <Description>Install Puppet Agent from razor server</Description>
         <Order>2</Order>
-        <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.4.3.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
+        <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
       </RunSynchronousCommand>
 
       <RunSynchronousCommand wcm:action="add">


### PR DESCRIPTION
Puppet agent 3.4.3 is installed on Windows nodes that has the support for getting the facts of failover cluster network. Puppet agent run fails on the HyperV nodes where failover cluster feature is installed.