### PR TITLE
ASM-2476 Puppet agent fails on hyper-v host after configuration

### DIFF
--- a/tasks/windows2012.task/default-unattended.xml.erb
+++ b/tasks/windows2012.task/default-unattended.xml.erb
@@ -119,7 +119,7 @@
         <RunSynchronousCommand wcm:action="add">
           <Description>Install Puppet Agent from razor server</Description>
           <Order>2</Order>
-          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
+          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=&quot;NetworkService&quot; </Path>
         </RunSynchronousCommand>
         <%=
           if os.ntp_server

--- a/tasks/windows2012.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2012.task/hyper-v-unattended.xml.erb
@@ -102,7 +102,7 @@
       <RunSynchronousCommand wcm:action="add">
         <Description>Install Puppet Agent from razor server</Description>
         <Order>2</Order>
-        <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
+        <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=&quot;NetworkService&quot; </Path>
       </RunSynchronousCommand>
 
       <RunSynchronousCommand wcm:action="add">


### PR DESCRIPTION
Response from Puppetlabs Team:

The ability to configure the service user for Windows wasn't added until Puppet 3.4, so specifying PUPPET_AGENT_ACCOUNT_USER=Administrator in 3.3.2 would have been ignored. If you look at a machine that has the Puppet 3.3.2 agent installed, it's service should be running as LocalSystem
I suggest you do one of the following:
• PUPPET_AGENT_ACCOUNT_USER is optional, so you can remove it (along with PUPPET_AGENT_ACCOUNT_PASSWORD) if you don't have a compelling reason to reconfigure the service user.
• If you need to specify a PUPPET_AGENT_ACCOUNT_USER to configure the service user for your install, create and configure a new account or use an existing account like NetworkService