### PR TITLE
ASM 3584 - Add DHCP option to build-razor-winpe script

### DIFF
--- a/build-winpe/build-razor-winpe.ps1
+++ b/build-winpe/build-razor-winpe.ps1
@@ -2,6 +2,7 @@
 # To run this script:
 # powershell -executionpolicy bypass -file build-razor-winpe.ps1 [ASM appliance IP -or- DHCP] [Your Windows .iso name] [New Windows .iso name]
 #
+#
 param(
     [Cmdletbinding(PositionalBinding = $false)]
     [string]$asmapplianceip,


### PR DESCRIPTION
If user enters "DHCP" instead of an ASM appliance IP, we'll build the .iso to point to the DHCP server as the razor server.  