### PR TITLE
ASM-1973 do not specify git location for dell-asm-util

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'hashie', '~> 2.0.5'
 gem 'aescrypt'
 gem 'rest-client'
 gem 'fast_gettext', '~> 0.8.1'
-gem 'dell-asm-util', :git => 'https://github.com/dell-asm/dell-asm-util.git'
+gem 'dell-asm-util', '~> 0.1.0'
 
 ## support for various tasks and utility
 # This allows us to encrypt plain-text-in-the-DB passwords when they travel,


### PR DESCRIPTION
This was causing the appliance not to use the dell-asm-util gem that
was already installed; instead bundle install always tried to fetch
from github which failed.

This means that the gem will have to be manually installed for now.