### PR TITLE
ASM-5262 Removed firstdisk specifier for local on esxi kickstart.

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -20,8 +20,6 @@ if options && !options.empty?
   boot_device = options['target_boot_device'] || ''
   if boot_device.include?("SD")
     disk_arg += "=usb-storage"
-  else
-    disk_arg += "=local"
   end
 end
 "clearpart --firstdisk#{disk_arg} --overwritevmfs


### PR DESCRIPTION
This was causing issues with racks.  ESXi, for some reason, doesn't see the virtual disks being created as local.