### PR TITLE
ASM-5142 StaticIP support for Linux ISO install

### DIFF
--- a/tasks/redhat.task/kernel_args.erb
+++ b/tasks/redhat.task/kernel_args.erb
@@ -1,1 +1,29 @@
-ks=<%= file_url("kickstart") %> network ksdevice=bootif BOOTIF=01-${netX/mac}
+<%
+
+   options = node.policy.node_metadata["installer_options"]
+   k_opts = ""
+   if options && options["network_configuration"]
+     require "json"
+     require "asm/network_configuration"
+
+     kernel_opts = {}
+
+     network_config = ASM::NetworkConfiguration.new(JSON.parse(options["network_configuration"]))
+     partition = network_config.get_partitions("PXE").first
+     if partition
+       kernel_opts[:ksdevice] = partition.mac_address if partition.mac_address
+
+       network = partition.networkObjects.find { |p| p["type"] == "PXE" }
+       static = network.static && network.staticNetworkConfiguration
+       if static
+         kernel_opts.merge!(:ip => static.ipAddress, :netmask => static.subnet, :gateway => static.gateway)
+         dns_server = [static.primaryDns, static.secondaryDns].compact.first
+         kernel_opts[:nameserver] = dns_server if dns_server
+       end
+     end
+     k_opts = kernel_opts.map { |k, v| "%s=%s" % [k, v] }.join(" ")
+   end
+
+%>
+
+ks=<%= file_url("kickstart") %> <%= k_opts.empty? ? "network ksdevice=bootif BOOTIF=01-${netX/mac}" : k_opts %>

--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -13,7 +13,35 @@ rootpw --iscrypted <%=
     asm_decrypted_password = ASM::Cipher.decrypt_string(node.root_password)
     UnixCrypt::SHA512.build(asm_decrypted_password)
 %>
-network --hostname <%= node.hostname %>
+<%
+
+   options = node.policy.node_metadata["installer_options"]
+   k_opts = ""
+   if options && options["network_configuration"]
+     require "json"
+     require "asm/network_configuration"
+
+     kernel_opts = {}
+
+     network_config = ASM::NetworkConfiguration.new(JSON.parse(options["network_configuration"]))
+     partition = network_config.get_partitions("PXE").first
+     if partition
+       kernel_opts["--device"] = partition.mac_address if partition.mac_address
+
+       network = partition.networkObjects.find { |p| p["type"] == "PXE" }
+       static = network.static && network.staticNetworkConfiguration
+       if static
+         kernel_opts["--bootproto"] = "static"
+         kernel_opts.merge!("--ip" => static.ipAddress, "--netmask" => static.subnet, "--gateway" => static.gateway)
+         dns_server = [static.primaryDns, static.secondaryDns].compact.first
+         kernel_opts["--nameserver"] = dns_server if dns_server
+       end
+     end
+     k_opts = kernel_opts.map { |k, v| "%s=%s" % [k, v] }.join(" ")
+   end
+
+%>
+network --hostname <%= node.hostname %> <%= k_opts unless k_opts.empty? %>
 firewall --enabled --ssh
 authconfig --enableshadow --passalgo=sha512 --enablefingerprint
 <%=

--- a/tasks/vmware_esxi.task/boot.cfg.erb
+++ b/tasks/vmware_esxi.task/boot.cfg.erb
@@ -44,7 +44,7 @@
               network = partition.networkObjects.find { |p| p["type"] == "PXE" }
               static = network.static && network.staticNetworkConfiguration
               if static
-                kernel_opts.merge!(:ip => static.ipAddress, :subnet => static.subnet, :gateway => static.gateway)
+                kernel_opts.merge!(:ip => static.ipAddress, :netmask => static.subnet, :gateway => static.gateway)
                 dns_server = [static.primaryDns, static.secondaryDns].compact.first
                 kernel_opts[:nameserver] = dns_server if dns_server
               end


### PR DESCRIPTION
Add support for StaticIP to be used for razor install on RHEL and CentOS.
Uses the network_config object passed into the node metadata.