### PR TITLE
ASM-6647 Do not eject CD after ESXi install

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -66,7 +66,7 @@ else
 end
 %>
 
-reboot
+reboot --noeject
 
 # %include /tmp/networkconfig
 %pre --interpreter=busybox


### PR DESCRIPTION
When the reboot command is issued during ESXi install the installer
tries to eject the CD. In recent versions of iDrac that will cause
virtual media to become disconnected. Work around by passing the
--noeject argument.