### PR TITLE
ASM-6906 Do not set hosts entry if already set

### DIFF
--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -19,7 +19,9 @@ fi
 # which there is no RHN registration
 
 #add the puppet master host entry in /etc/hosts
-echo "<%= URI.parse(repo_url).host %> dellasm" >> /etc/hosts
+if ! grep -q dellasm /etc/hosts; then
+  echo "<%= URI.parse(repo_url).host %> dellasm" >> /etc/hosts
+fi
 
 # Install the puppet agent
 # TODO: Need to transition to installing these rpms via yum. That will fix problems


### PR DESCRIPTION
The final step of the redhat post_install script is to remove itself
from /etc/rc.d/rc.local so that it doesn't get re-run when the server
next reboots. However it's possible for it to execute twice if the
server gets rebooted while it is running. In that case it was adding a
duplicate dellasm hosts file entry. That will cause problems later on
if e.g. you use puppet to manage that entry. In that case puppet will
only update the second of the entries and the server will continue to
use the first IP.