### PR TITLE
ASM-7011 Update NTP configuration for HyperV server during initial installation

### DIFF
--- a/tasks/windows2012.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2012.task/hyper-v-unattended.xml.erb
@@ -110,6 +110,30 @@
         <Order>3</Order>
         <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v ASMScript /t REG_SZ /d &quot;cmd /c c:\ASMPostInstall\ASMScript.cmd&quot; /f</Path>
       </RunSynchronousCommand>
+
+      <%=
+          if os.ntp_server
+             ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
+             command1 = "cmd /c w32tm /config /manualpeerlist:\"#{ntp_servers}\" /syncfromflags:MANUAL"
+             command2 = "cmd /c &quot;sc config w32time start= delayed-auto&quot;"
+             command3 = "powershell.exe -Command restart-Service w32time"
+             str = "<RunSynchronousCommand wcm:action=\"add\">
+          <Description>NTP Server configuration</Description>
+          <Order>3</Order>
+          <Path>#{command1}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Configure service w32time as Delayed Automatic</Description>
+          <Order>4</Order>
+          <Path>#{command2}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Start time configuration</Description>
+          <Order>5</Order>
+          <Path>#{command3}</Path>
+        </RunSynchronousCommand>"
+          end
+        %>
     </RunSynchronous>
     </component>
   </settings>


### PR DESCRIPTION
Update the NTP configuration on the server as part of OS installation so that puppet check-in happens with correct time configuration.