### PR TITLE
ASM-7174 CentOS 6.7 OS fails complaining libselinux-ruby-xxx.rpm missing

### DIFF
--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -74,7 +74,9 @@ zlib-devel
 openssl-devel
 readline-devel
 augeas-libs
+<% if task.os_version == '7' %>
 libselinux-ruby
+<% end %>
 ruby-irb
 ruby-rdoc
 ruby

--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -29,7 +29,15 @@ fi
 # libselinux-ruby problem below where the rpm is already included in RHEL 7.2
 mkdir /tmp/mnt
 mount -o nolock,username=readonly,password=readonly //<%= URI.parse(repo_url).host %>/razor /tmp/mnt
-if rpm -q libselinux-ruby; then
+if rpm -q libselinux-2.0.94-5.3.el6_4.1.x86_64; then
+  #Due to issue with Centos 6.7 .iso we can no longer install libselinux-ruby from kickstart so we 
+  #must check the correct version of libselinux and install the correct version of libselinux-ruby
+  #if Centos 6.5 we need to install corect version of libselinux-ruby based on libselinux version
+  rpm -ivh `ls /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/*.rpm | grep -v libselinux-ruby-2.0.94-5.8.el6.x86_64.rpm`
+elif rpm -q libselinux-2.0.94-5.8.el6.x86_64; then
+  #if Centos 6.6 or 6.7 we need to install corect version of libselinux-ruby based on libselinux version
+  rpm -ivh `ls /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/*.rpm | grep -v libselinux-ruby-2.0.94-5.3.el6_4.1.x86_64.rpm`
+elif rpm -q libselinux-ruby; then
   # HACK: RHEL 7.2 already has libselinux-ruby installed. Skip in that case.
   rpm -ivh `ls /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/*.rpm | grep -v libselinux-ruby`
 else


### PR DESCRIPTION
Centos 6.7 .iso can't install libselinux-ruby and kickstart is not
behaving properly so for centos/redhat 6 installs we'll install
libselinux-ruby with the puppet agent depending on the version of
libselinux installed

This pull request should be merged with: https://github.com/dell-asm/asm-automation/pull/483