### PR TITLE
ASM-7450 Increase puppet config timeout

### DIFF
--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -81,6 +81,7 @@ cat > /etc/puppet/puppet.conf << EOF
     logdir = /var/log/puppet
     rundir = /var/run/puppet
     ssldir = \$vardir/ssl
+    configtimeout = 600
 [agent]
     classfile   = \$vardir/classes.txt
     localconfig = \$vardir/localconfig

--- a/tasks/suse11.task/post_install.erb
+++ b/tasks/suse11.task/post_install.erb
@@ -46,6 +46,7 @@ cat > /etc/puppet/puppet.conf << EOF
     logdir = /var/log/puppet
     rundir = /var/run/puppet
     ssldir = \$vardir/ssl
+    configtimeout = 600
 [agent]
     classfile   = \$vardir/classes.txt
     localconfig = \$vardir/localconfig

--- a/tasks/windows2008.task/default-unattended.xml.erb
+++ b/tasks/windows2008.task/default-unattended.xml.erb
@@ -101,7 +101,7 @@
         <RunSynchronousCommand wcm:action="add">
           <Description>Configure Puppet Agent config timeout</Description>
           <Order>6</Order>
-          <Path>puppet agent set configtimeout 600</Path>
+          <Path>puppet config set configtimeout 600</Path>
         </RunSynchronousCommand>
       </RunSynchronous>
     </component>

--- a/tasks/windows2008.task/default-unattended.xml.erb
+++ b/tasks/windows2008.task/default-unattended.xml.erb
@@ -73,8 +73,15 @@
         <RunSynchronousCommand wcm:action="add">
           <Description>Install Puppet Agent from razor server</Description>
           <Order>2</Order>
-          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER="dellasm" PUPPET_AGENT_CERTNAME="<%= node.policy.node_metadata['installer_options']['agent_certname'] %>" PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD="<%= ASM::Cipher.decrypt_string(node.root_password) %>"</Path>
+          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=&quot;NetworkService&quot; </Path>
         </RunSynchronousCommand>
+
+        <RunSynchronousCommand wcm:action="add">
+         <Description>Updating registry to run puppet config timeout setup</Description>
+         <Order>3</Order>
+         <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set configtimeout 600 --section main &quot; /f</Path>
+        </RunSynchronousCommand>
+
         <%=
           if os.ntp_server
              ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
@@ -83,26 +90,22 @@
              command3 = "powershell.exe -Command restart-Service w32time"
              str = "<RunSynchronousCommand wcm:action=\"add\">
           <Description>NTP Server configuration</Description>
-          <Order>3</Order>
+          <Order>4</Order>
           <Path>#{command1}</Path>
         </RunSynchronousCommand>
 <RunSynchronousCommand wcm:action=\"add\">
           <Description>Configure service w32time as Delayed Automatic</Description>
-          <Order>4</Order>
+          <Order>5</Order>
           <Path>#{command2}</Path>
         </RunSynchronousCommand>
 <RunSynchronousCommand wcm:action=\"add\">
           <Description>Start time configuration</Description>
-          <Order>5</Order>
+          <Order>6</Order>
           <Path>#{command3}</Path>
         </RunSynchronousCommand>"
           end
         %>
-        <RunSynchronousCommand wcm:action="add">
-          <Description>Configure Puppet Agent config timeout</Description>
-          <Order>6</Order>
-          <Path>puppet config set configtimeout 600</Path>
-        </RunSynchronousCommand>
+
       </RunSynchronous>
     </component>
 

--- a/tasks/windows2008.task/default-unattended.xml.erb
+++ b/tasks/windows2008.task/default-unattended.xml.erb
@@ -98,6 +98,11 @@
         </RunSynchronousCommand>"
           end
         %>
+        <RunSynchronousCommand wcm:action="add">
+          <Description>Configure Puppet Agent config timeout</Description>
+          <Order>6</Order>
+          <Path>puppet agent set configtimeout 600</Path>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
 

--- a/tasks/windows2012.task/default-unattended.xml.erb
+++ b/tasks/windows2012.task/default-unattended.xml.erb
@@ -121,6 +121,13 @@
           <Order>2</Order>
           <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=&quot;NetworkService&quot; </Path>
         </RunSynchronousCommand>
+
+      <RunSynchronousCommand wcm:action="add">
+        <Description>Updating registry to run ASM script on every reboot</Description>
+        <Order>3</Order>
+        <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set configtimeout 600 --section main &quot; /f</Path>
+      </RunSynchronousCommand>
+
         <%=
           if os.ntp_server
              ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
@@ -129,26 +136,22 @@
              command3 = "powershell.exe -Command restart-Service w32time"
              str = "<RunSynchronousCommand wcm:action=\"add\">
           <Description>NTP Server configuration</Description>
-          <Order>3</Order>
+          <Order>4</Order>
           <Path>#{command1}</Path>
         </RunSynchronousCommand>
         <RunSynchronousCommand wcm:action=\"add\">
           <Description>Configure service w32time as Delayed Automatic</Description>
-          <Order>4</Order>
+          <Order>5</Order>
           <Path>#{command2}</Path>
         </RunSynchronousCommand>
         <RunSynchronousCommand wcm:action=\"add\">
           <Description>Start time configuration</Description>
-          <Order>5</Order>
+          <Order>6</Order>
           <Path>#{command3}</Path>
         </RunSynchronousCommand>"
           end
         %>
-        <RunSynchronousCommand wcm:action="add">
-          <Description>Configure Puppet Agent config timeout</Description>
-          <Order>6</Order>
-          <Path>puppet config set configtimeout 600</Path>
-        </RunSynchronousCommand>
+
       </RunSynchronous>
     </component>
 

--- a/tasks/windows2012.task/default-unattended.xml.erb
+++ b/tasks/windows2012.task/default-unattended.xml.erb
@@ -147,7 +147,7 @@
         <RunSynchronousCommand wcm:action="add">
           <Description>Configure Puppet Agent config timeout</Description>
           <Order>6</Order>
-          <Path>puppet agent set configtimeout 600</Path>
+          <Path>puppet config set configtimeout 600</Path>
         </RunSynchronousCommand>
       </RunSynchronous>
     </component>

--- a/tasks/windows2012.task/default-unattended.xml.erb
+++ b/tasks/windows2012.task/default-unattended.xml.erb
@@ -144,6 +144,11 @@
         </RunSynchronousCommand>"
           end
         %>
+        <RunSynchronousCommand wcm:action="add">
+          <Description>Configure Puppet Agent config timeout</Description>
+          <Order>6</Order>
+          <Path>puppet agent set configtimeout 600</Path>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
 

--- a/tasks/windows2012.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2012.task/hyper-v-unattended.xml.erb
@@ -138,7 +138,7 @@
         <RunSynchronousCommand wcm:action="add">
           <Description>Configure Puppet Agent config timeout</Description>
           <Order>6</Order>
-          <Path>puppet agent set configtimeout 600</Path>
+          <Path>puppet config set configtimeout 600</Path>
         </RunSynchronousCommand>
     </RunSynchronous>
     </component>

--- a/tasks/windows2012.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2012.task/hyper-v-unattended.xml.erb
@@ -114,7 +114,7 @@
 
        <RunSynchronousCommand wcm:action="add">
         <Description>Updating registry to run Puppet config script on every reboot</Description>
-        <Order>3</Order>
+        <Order>4</Order>
         <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set configtimeout 600 --section main &quot; /f</Path>
       </RunSynchronousCommand>
 

--- a/tasks/windows2012.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2012.task/hyper-v-unattended.xml.erb
@@ -112,6 +112,12 @@
         <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v ASMScript /t REG_SZ /d &quot;cmd /c c:\ASMPostInstall\ASMScript.cmd&quot; /f</Path>
       </RunSynchronousCommand>
 
+       <RunSynchronousCommand wcm:action="add">
+        <Description>Updating registry to run Puppet config script on every reboot</Description>
+        <Order>3</Order>
+        <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set configtimeout 600 --section main &quot; /f</Path>
+      </RunSynchronousCommand>
+
       <%=
           if os.ntp_server
              ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
@@ -120,26 +126,21 @@
              command3 = "powershell.exe -Command restart-Service w32time"
              str = "<RunSynchronousCommand wcm:action=\"add\">
           <Description>NTP Server configuration</Description>
-          <Order>3</Order>
+          <Order>5</Order>
           <Path>#{command1}</Path>
         </RunSynchronousCommand>
         <RunSynchronousCommand wcm:action=\"add\">
           <Description>Configure service w32time as Delayed Automatic</Description>
-          <Order>4</Order>
+          <Order>6</Order>
           <Path>#{command2}</Path>
         </RunSynchronousCommand>
         <RunSynchronousCommand wcm:action=\"add\">
           <Description>Start time configuration</Description>
-          <Order>5</Order>
+          <Order>7</Order>
           <Path>#{command3}</Path>
         </RunSynchronousCommand>"
           end
         %>
-        <RunSynchronousCommand wcm:action="add">
-          <Description>Configure Puppet Agent config timeout</Description>
-          <Order>6</Order>
-          <Path>puppet config set configtimeout 600</Path>
-        </RunSynchronousCommand>
     </RunSynchronous>
     </component>
   </settings>

--- a/tasks/windows2012.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2012.task/hyper-v-unattended.xml.erb
@@ -135,6 +135,11 @@
         </RunSynchronousCommand>"
           end
         %>
+        <RunSynchronousCommand wcm:action="add">
+          <Description>Configure Puppet Agent config timeout</Description>
+          <Order>6</Order>
+          <Path>puppet agent set configtimeout 600</Path>
+        </RunSynchronousCommand>
     </RunSynchronous>
     </component>
   </settings>


### PR DESCRIPTION
Updated timeout to 10 minutes while installing puppet agent on Server / VM. This will ensure we have correct timeout value on all supported operating system