### PR TITLE
ASM-7220 ESXi installation is failing on R730XD in case there are additonal SATA disks on the server

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -24,7 +24,7 @@ if options && !options.empty?
   end
 end
 
-if boot_device == "VSAN_AHCI"
+if boot_device == "AHCI_VSAN"
   "%include /tmp/disk_info"
 else
   "clearpart --firstdisk#{disk_arg} --overwritevmfs


### PR DESCRIPTION
Checked-in code has an typo. Due to which kickstart include statement was not included.