### PR TITLE
ASM-7644 Sync the NTP time before puppet run

### DIFF
--- a/tasks/windows2012.task/default-unattended.xml.erb
+++ b/tasks/windows2012.task/default-unattended.xml.erb
@@ -108,26 +108,6 @@
           <Path>powershell.exe -ExecutionPolicy Bypass Set-NetFirewallProfile -Enabled False -LogFileName c:\firewall.log -ErrorAction Inquire -Verbose</Path>
         </RunSynchronousCommand>
 -->
-<!-- adding puppet master server to hosts file -->
-        <RunSynchronousCommand wcm:action="add">
-          <Description>Add to Hosts file</Description>
-          <Order>1</Order>
-          <Path>powershell.exe -Command "Add-Content \"c:\windows\system32\drivers\etc\hosts\" \"`n<%= URI.parse(repo_url).host %> dellasm\""</Path>
-        </RunSynchronousCommand>
-
-<!-- Replace PUPPETSERVER with your puppet server -->
-        <RunSynchronousCommand wcm:action="add">
-          <Description>Install Puppet Agent from razor server</Description>
-          <Order>2</Order>
-          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=&quot;NetworkService&quot; </Path>
-        </RunSynchronousCommand>
-
-      <RunSynchronousCommand wcm:action="add">
-        <Description>Updating registry to run ASM script on every reboot</Description>
-        <Order>3</Order>
-        <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set configtimeout 600 --section main &quot; /f</Path>
-      </RunSynchronousCommand>
-
         <%=
           if os.ntp_server
              ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
@@ -136,21 +116,42 @@
              command3 = "powershell.exe -Command restart-Service w32time"
              str = "<RunSynchronousCommand wcm:action=\"add\">
           <Description>NTP Server configuration</Description>
-          <Order>4</Order>
+          <Order>1</Order>
           <Path>#{command1}</Path>
         </RunSynchronousCommand>
         <RunSynchronousCommand wcm:action=\"add\">
           <Description>Configure service w32time as Delayed Automatic</Description>
-          <Order>5</Order>
+          <Order>2</Order>
           <Path>#{command2}</Path>
         </RunSynchronousCommand>
         <RunSynchronousCommand wcm:action=\"add\">
           <Description>Start time configuration</Description>
-          <Order>6</Order>
+          <Order>3</Order>
           <Path>#{command3}</Path>
         </RunSynchronousCommand>"
           end
         %>
+
+<!-- adding puppet master server to hosts file -->
+        <RunSynchronousCommand wcm:action="add">
+          <Description>Add to Hosts file</Description>
+          <Order>4</Order>
+          <Path>powershell.exe -Command "Add-Content \"c:\windows\system32\drivers\etc\hosts\" \"`n<%= URI.parse(repo_url).host %> dellasm\""</Path>
+        </RunSynchronousCommand>
+
+<!-- Replace PUPPETSERVER with your puppet server -->
+        <RunSynchronousCommand wcm:action="add">
+          <Description>Install Puppet Agent from razor server</Description>
+          <Order>5</Order>
+          <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=&quot;NetworkService&quot; </Path>
+        </RunSynchronousCommand>
+
+      <RunSynchronousCommand wcm:action="add">
+        <Description>Updating registry to run ASM script on every reboot</Description>
+        <Order>6</Order>
+        <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set configtimeout 600 --section main &quot; /f</Path>
+      </RunSynchronousCommand>
+
 
       </RunSynchronous>
     </component>


### PR DESCRIPTION
Change the unattend order on windows 2012 to sync the NTP time before
running puppet.  We've found that a time sync with a running puppet
agent can cause the agent to hang