### PR TITLE
ASM-7709 setup ntp before puppet config

### DIFF
--- a/tasks/windows2008.task/default-unattended.xml.erb
+++ b/tasks/windows2008.task/default-unattended.xml.erb
@@ -62,50 +62,55 @@
           <Path>powershell.exe -ExecutionPolicy Bypass Set-NetFirewallProfile -Enabled False -LogFileName c:\firewall.log -ErrorAction Inquire -Verbose</Path>
         </RunSynchronousCommand>
 -->
+        <%=
+          if os.ntp_server
+             ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
+             command1 = "cmd /c w32tm /config /manualpeerlist:\"#{ntp_servers}\" /syncfromflags:MANUAL"
+             command2 = "cmd /c &quot;sc config w32time start= auto&quot;"
+             command3 = "powershell.exe -Command restart-Service w32time"
+             str = "<RunSynchronousCommand wcm:action=\"add\">
+          <Description>NTP Server configuration</Description>
+          <Order>1</Order>
+          <Path>#{command1}</Path>
+        </RunSynchronousCommand>
+<RunSynchronousCommand wcm:action=\"add\">
+          <Description>Configure service w32time as Automatic</Description>
+          <Order>2</Order>
+          <Path>#{command2}</Path>
+        </RunSynchronousCommand>
+<RunSynchronousCommand wcm:action=\"add\">
+          <Description>Start time configuration</Description>
+          <Order>3</Order>
+          <Path>#{command3}</Path>
+        </RunSynchronousCommand>"
+          end
+        %>
+
 <!-- adding puppet master server to hosts file -->
         <RunSynchronousCommand wcm:action="add">
           <Description>Add to Hosts file</Description>
-          <Order>1</Order>
+          <Order>4</Order>
           <Path>powershell.exe -Command "Add-Content \"c:\windows\system32\drivers\etc\hosts\" \"`n<%= URI.parse(repo_url).host %> dellasm\""</Path>
         </RunSynchronousCommand>
 
 <!-- Replace PUPPETSERVER with your puppet server -->
         <RunSynchronousCommand wcm:action="add">
           <Description>Install Puppet Agent from razor server</Description>
-          <Order>2</Order>
+          <Order>5</Order>
           <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=&quot;NetworkService&quot; </Path>
         </RunSynchronousCommand>
 
         <RunSynchronousCommand wcm:action="add">
          <Description>Updating registry to run puppet config timeout setup</Description>
-         <Order>3</Order>
+         <Order>6</Order>
          <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set configtimeout 600 --section main &quot; /f</Path>
         </RunSynchronousCommand>
 
-        <%=
-          if os.ntp_server
-             ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
-             command1 = "cmd /c w32tm /config /manualpeerlist:\"#{ntp_servers}\" /syncfromflags:MANUAL"
-             command2 = "cmd /c &quot;sc config w32time start= delayed-auto&quot;"
-             command3 = "powershell.exe -Command restart-Service w32time"
-             str = "<RunSynchronousCommand wcm:action=\"add\">
-          <Description>NTP Server configuration</Description>
-          <Order>4</Order>
-          <Path>#{command1}</Path>
+        <RunSynchronousCommand wcm:action="add">
+         <Description>Configure service puppet as delayed Automatic</Description>
+         <Order>7</Order>
+         <Path>cmd /c &quot;sc config puppet start= delayed-auto&quot;</Path>
         </RunSynchronousCommand>
-<RunSynchronousCommand wcm:action=\"add\">
-          <Description>Configure service w32time as Delayed Automatic</Description>
-          <Order>5</Order>
-          <Path>#{command2}</Path>
-        </RunSynchronousCommand>
-<RunSynchronousCommand wcm:action=\"add\">
-          <Description>Start time configuration</Description>
-          <Order>6</Order>
-          <Path>#{command3}</Path>
-        </RunSynchronousCommand>"
-          end
-        %>
-
       </RunSynchronous>
     </component>
 

--- a/tasks/windows2012.task/default-unattended.xml.erb
+++ b/tasks/windows2012.task/default-unattended.xml.erb
@@ -112,7 +112,7 @@
           if os.ntp_server
              ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
              command1 = "cmd /c w32tm /config /manualpeerlist:\"#{ntp_servers}\" /syncfromflags:MANUAL"
-             command2 = "cmd /c &quot;sc config w32time start= delayed-auto&quot;"
+             command2 = "cmd /c &quot;sc config w32time start= auto&quot;"
              command3 = "powershell.exe -Command restart-Service w32time"
              str = "<RunSynchronousCommand wcm:action=\"add\">
           <Description>NTP Server configuration</Description>
@@ -120,7 +120,7 @@
           <Path>#{command1}</Path>
         </RunSynchronousCommand>
         <RunSynchronousCommand wcm:action=\"add\">
-          <Description>Configure service w32time as Delayed Automatic</Description>
+          <Description>Configure service w32time as Automatic</Description>
           <Order>2</Order>
           <Path>#{command2}</Path>
         </RunSynchronousCommand>
@@ -152,7 +152,11 @@
         <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set configtimeout 600 --section main &quot; /f</Path>
       </RunSynchronousCommand>
 
-
+      <RunSynchronousCommand wcm:action="add">
+         <Description>Configure service puppet as delayed Automatic</Description>
+         <Order>7</Order>
+         <Path>cmd /c &quot;sc config puppet start= delayed-auto&quot;</Path>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
 


### PR DESCRIPTION
This commit addresses the issue where the ntp service interferes
with the puppet-agent process on the Windows 2008 and 2012. When
the interference occurs, the puppet-agent is stuck indefinitely
until the system time catches up to new time set by the ntp service.
This typically takes a few hours to sync, so the deployment times
out and fails.

In order to resolve this issue, default-unattended.xml.erb files for
the Windows 2008 and 2012 are updated. The RunSynchronous commands
are rearranged to configure the ntp service before installing and
configuring the puppet service. Additionally, the ntp service is
set to start up at the system startup while the puppet service is
set to start after other system services (including the ntp) to
reduce the possibility of the interference.

The validation results show that this removed the deployment fail-
ures from the environment where ntp/puppet conflicts could be seen
for every deployment. Also deploying the Windows VM's without the
ntp server(s) also function correctly.