### PR TITLE
ASM-7503 ESXi razor task change to support SATADOM boot option

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -97,8 +97,8 @@ for disk in $disk_paths; do
     fi
     model=`localcli storage core device list -d $device | grep -i "Model:" | cut -d ":" -f2`
     model=`echo $model | awk '{$1=$1;print}'`
-    echo clearpart --firstdisk=${model},local --overwritevmfs > /tmp/disk_info
-    echo install --firstdisk=${model},local --overwritevmfs >> /tmp/disk_info
+    echo clearpart --firstdisk=\"${model}\",local --overwritevmfs > /tmp/disk_info
+    echo install --firstdisk=\"${model}\",local --overwritevmfs >> /tmp/disk_info
   fi
 done
 echo "Pre execution done"


### PR DESCRIPTION
The model exposed by SATADOM drives seems to have spaces, causing
clearpart and install commands to fail for the ATA disks.

The solution to this problem is to fix the space issue by quoting the
model value.
