### PR TITLE
ASM-7920 VSAN Deployment Fails under certain disk conditions

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -104,7 +104,7 @@ for disk in $disk_paths; do
 done
 
 # Cleanup VSAN Partition data
-disk_paths=`localcli storage core device list | grep "Devfs Path"`
+disk_paths=`localcli storage core device list | grep "Devfs Path" | grep -vi "cdrom"`
 for disk in $disk_paths; do
   if [ "$disk" == "Path:" -o "$disk" == "Devfs" ] ;  then
     continue


### PR DESCRIPTION
Post-installation stage of server was failing while cleaning up the existing partitions on the disk. On R630 servers. script was getting memory error while trying to process CDROM devices.
Skipped the cdrom device from the processing list to avoid error.