### PR TITLE
ASM-8050 Set initial puppet run interval to 5 minutes for linux installs

### DIFF
--- a/tasks/common/puppet_conf.erb
+++ b/tasks/common/puppet_conf.erb
@@ -1,0 +1,14 @@
+#update puppet.conf file
+cat > /etc/puppet/puppet.conf << EOF
+[main]
+    server = dellasm
+    logdir = /var/log/puppet
+    rundir = /var/run/puppet
+    ssldir = \$vardir/ssl
+    configtimeout = 600
+    runinterval = 5m
+[agent]
+    classfile   = \$vardir/classes.txt
+    localconfig = \$vardir/localconfig
+    certname    = <%= node.policy.node_metadata["installer_options"]["agent_certname"] %>
+EOF

--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -74,20 +74,7 @@ if [ "$ntp_server" != "" ]; then
 <% end %>
 fi
 
-#update puppet.conf file
-cat > /etc/puppet/puppet.conf << EOF
-[main]
-    server = dellasm
-    logdir = /var/log/puppet
-    rundir = /var/run/puppet
-    ssldir = \$vardir/ssl
-    configtimeout = 600
-[agent]
-    classfile   = \$vardir/classes.txt
-    localconfig = \$vardir/localconfig
-    certname    = <%= node.policy.node_metadata['installer_options']['agent_certname'] %>
-
-EOF
+<%= render_template("puppet_conf") %>
 
 # Nagios NRPE configuration, used only for C* series machines
 if [[ "$(/usr/bin/facter productname)" =~ ^PowerEdge\ C62[0-9]+ ]]; then

--- a/tasks/suse11.task/post_install.erb
+++ b/tasks/suse11.task/post_install.erb
@@ -37,21 +37,9 @@ chmod 755 /etc/init.d/puppet
 umount /tmp/mnt
 rm -rf /tmp/mnt
 
-#update puppet.conf file
 mkdir /etc/puppet
 touch /etc/puppet/puppet.conf
-cat > /etc/puppet/puppet.conf << EOF
-[main]
-    server = dellasm
-    logdir = /var/log/puppet
-    rundir = /var/run/puppet
-    ssldir = \$vardir/ssl
-    configtimeout = 600
-[agent]
-    classfile   = \$vardir/classes.txt
-    localconfig = \$vardir/localconfig
-    certname    = <%= node.policy.node_metadata['installer_options']['agent_certname'] %>
-EOF
+<%= render_template("puppet_conf") %>
 
 # For debugging, just in case, dump out the modified configuration file.
 echo ====================[ /etc/puppet/puppet.conf ]=========================

--- a/tasks/suse12.task/post_install.erb
+++ b/tasks/suse12.task/post_install.erb
@@ -18,19 +18,7 @@ zypper --non-interactive --no-gpg-checks install /tmp/mnt/puppet-agent/suse12/*.
 umount /tmp/mnt
 rm -rf /tmp/mnt
 
-#update puppet.conf file
-cat > /etc/puppet/puppet.conf << EOF
-[main]
-    server = dellasm
-    logdir = /var/log/puppet
-    rundir = /var/run/puppet
-    ssldir = \$vardir/ssl
-[agent]
-    classfile   = \$vardir/classes.txt
-    localconfig = \$vardir/localconfig
-    certname    = <%= node.policy.node_metadata['installer_options']['agent_certname'] %>
-
-EOF
+<%= render_template("puppet_conf") %>
 
 # For debugging, just in case, dump out the modified confirmation file.
 #echo ====================[ /etc/puppet/puppet.conf ]=========================


### PR DESCRIPTION
By default, puppet runs are 30 minutes. Sometimes, that causes wastage of
time for ASM needed configuration in worst case scenarios. We reduce the
runinterval to 5 minutes so that this wastage is minimized.

Also we moved duplicated puppet.conf lines into common place.

Note: There will be another PR later for windows install.