### PR TITLE
ASM- 8293 ESXi VSAN SATADOM deployment is installing ESXi on different disk

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -94,7 +94,7 @@ for disk in $disk_paths; do
   if [ $? -eq 0 ]; then
     local_sas=`localcli storage core device list -d $device | grep -i "Is SAS: false"`
     local_ata_dell=`localcli storage core device list -d $device | grep -iE "DELL Serial"`
-    if [ $? -ne 0 -a "$local_ata_dell" -ne ""] ; then
+    if [ -z "$local_sas" -a -z "$local_ata_dell"] ; then
       continue
     fi
 


### PR DESCRIPTION
On VMware shell, script is executed as normal shell instead of bash shell. Script changes added recently was not working as a result the last ATA disk in the enumeration is selected for the OS installation. Updated the script based on "SHELL" to ensure we select the correct disk device.