### PR TITLE
ASM-8293 ESXi VSAN SATADOM deployment is installing ESXi on different disk

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -94,7 +94,7 @@ for disk in $disk_paths; do
   if [ $? -eq 0 ]; then
     local_sas=`localcli storage core device list -d $device | grep -i "Is SAS: false"`
     local_ata_dell=`localcli storage core device list -d $device | grep -iE "DELL Serial"`
-    if [ -z "$local_sas" -a -z "$local_ata_dell"] ; then
+    if [ -z "$local_sas" -a -z "$local_ata_dell" ] ; then
       continue
     fi
 


### PR DESCRIPTION
if test condition was missing a space at the end, leading to Shell script failure. Updated script to ensure all checks are applied to the servers