### PR TITLE
ASM-8322 Allow VSAN deployment to RAID volume

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -90,7 +90,7 @@ for disk in $disk_paths; do
     continue
   fi
   device=`basename $disk`
-  local_ata=`localcli storage core device list -d $device | grep -iE "Local ATA Disk|DELL Serial"`
+  local_ata=`localcli storage core device list -d $device | grep -iE "Local ATA Disk|DELL Serial|Local DELL Disk"`
   if [ $? -eq 0 ]; then
     local_sas=`localcli storage core device list -d $device | grep -i "Is SAS: false"`
     local_ata_dell=`localcli storage core device list -d $device | grep -iE "DELL Serial"`


### PR DESCRIPTION
The ESXi installer tries to determine the disk to use for OS
installation for VSAN_AHCI deployments by looking for disks with
names like "Local ATA Disk" or "DELL Serial". But PERC RAID volumes
are named "Local DELL Disk". Therefore the installer was failing to
find the install disk for VSAN_AHCI deployments to servers with RAID
volumes.