### PR TITLE
ASM-8325 Fix Esxi 6.5 SD installs

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -20,7 +20,7 @@ options = node.policy.node_metadata['installer_options']
 if options && !options.empty?
   boot_device = options['target_boot_device'] || ''
   if boot_device.include?("SD")
-    disk_arg += "=usb-storage"
+    disk_arg += "=usb"
   end
 end
 


### PR DESCRIPTION
Esxi 6.5 deployments to the SD card were failing due to the wrong
argument being used to specify USB storage for the installation
location