### PR TITLE
ASM-8332 VSAN Deployment to FC630 with RAID VD fails

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -93,7 +93,7 @@ for disk in $disk_paths; do
   local_ata=`localcli storage core device list -d $device | grep -iE "Local ATA Disk|DELL Serial|Local DELL Disk"`
   if [ $? -eq 0 ]; then
     local_sas=`localcli storage core device list -d $device | grep -i "Is SAS: false"`
-    local_ata_dell=`localcli storage core device list -d $device | grep -iE "DELL Serial"`
+    local_ata_dell=`localcli storage core device list -d $device | grep -iE "DELL Serial|Local DELL Disk"`
     if [ -z "$local_sas" -a -z "$local_ata_dell" ] ; then
       continue
     fi


### PR DESCRIPTION
For FC630 servers we need to perform the OS installation on virtual disk. This disk is presented to ESXi with Dell Serial or Local DELL Diks pattern. Updated pattern check for selection of the disk