### PR TITLE
ASM-8383 VMFS Datastore not deleted on all disks in VSAN

### DIFF
--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -119,6 +119,16 @@ for disk in $disk_paths; do
   fi
 done
 
+# Cleanup VMFS Partition data
+for DISK in $(ls /vmfs/devices/disks | grep -v vml);
+  do
+    DISK_PATH=/vmfs/devices/disks/${DISK}
+    VMFS_PARTITION_ID=$(partedUtil getptbl ${DISK_PATH} | grep vmfs | awk '{print $1}')
+    if [[ ! -z ${VMFS_PARTITION_ID} ]] && [[ ${VMFS_PARTITION_ID} -eq 3 ]]; then
+      partedUtil delete ${DISK_PATH} 3
+    fi
+done
+
 echo "Pre execution done"
 
 


### PR DESCRIPTION
During ESXi installation removed all existing VMFS partition to ensure all disks are available for VSAN deployment. This will also help for SD card and Satadom installation where previous ESXi installation datastores will be wiped off.