### PR TITLE
ASM-8553 support for RHEL/CentOS 7.3 added

### DIFF
--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -37,6 +37,9 @@ if rpm -q libselinux-2.0.94-5.3.el6_4.1.x86_64; then
 elif rpm -q libselinux-2.0.94-5.8.el6.x86_64; then
   #if Centos 6.6 or 6.7 we need to install corect version of libselinux-ruby based on libselinux version
   rpm -ivh `ls /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/*.rpm | grep -v libselinux-ruby-2.0.94-5.3.el6_4.1.x86_64.rpm`
+elif rpm -q libselinux-2.5-6.el7.x86_64; then
+  # RHEL 7.3 has libselinux-2.5-6 installed and requires different versions of packages
+  rpm -ivh --replacepkgs /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/rhel7_3/*.rpm
 elif rpm -q libselinux-ruby; then
   # HACK: RHEL 7.2 already has libselinux-ruby installed. Skip in that case.
   rpm -ivh `ls /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/*.rpm | grep -v libselinux-ruby`


### PR DESCRIPTION
For RHEL/CentOS 7.3, different versions of rpm packages must be
installed during the razor post install process. Required packages
are added in asm-automation under asm-automation/razorRpm/files/
puppet-agent/rhel7/x86_64/ directory. These files should be placed
in /var/lib/razor/repo-store/puppet-agent/rhel7/x86_64/rhel7_3
directory of the ASM appliance.

UPDATE: RHEL 7.3 baremetal does not get net-utils package installed
through the OS packages. Now the script checks and installs the
package where necessary.