### PR TITLE
ASM-8648: supports os_install on vm with CD/DVD drive

### DIFF
--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -90,9 +90,10 @@ policycoreutils-python
 # Only install the OS on the first virtual volume
 %pre
   FIRST_PERC_VOL=$(ls -1 /dev/disk/by-path/pci-*-scsi-0:[1-9]:0:0 | head -1)
-  if [ -z "${FIRST_PERC_VOL}" ]; then
-    FIRST_PERC_VOL=$(ls -1 /dev/disk/by-path/pci-*-scsi* | head -1)
-  fi
+   if [ -z "${FIRST_PERC_VOL}" ]; then
+     FIRST_PERC_VOL=$(ls -1 /dev/disk/by-path/pci-*-scsi* | sort -t- -k 4 | head -1)
+   fi
+
   echo "zerombr" > /tmp/ignoredisk
   echo "ignoredisk --only-use=$FIRST_PERC_VOL" >> /tmp/ignoredisk
   echo "clearpart --all --initlabel"  >> /tmp/ignoredisk


### PR DESCRIPTION
Previously os was installed to hardisk, However adding CD drive makes
OS to get installed on cd drive and fail to find installer files.

This PR will select the hard_disk device by selecting last line of the
command output to select drive.