### PR TITLE
ASM-9173 Set Windows w32time start trigger

### DIFF
--- a/tasks/windows2008.task/default-unattended.xml.erb
+++ b/tasks/windows2008.task/default-unattended.xml.erb
@@ -54,67 +54,65 @@
     <%= render_template("windows_static_network") %>
     <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <RunSynchronous>
-<!-- commenting this out since this does not work yet -->
-<!--
+        <!-- adding puppet master server to hosts file -->
         <RunSynchronousCommand wcm:action="add">
-          <Description>Disable firewall</Description>
-          <Order>1</Order>
-          <Path>powershell.exe -ExecutionPolicy Bypass Set-NetFirewallProfile -Enabled False -LogFileName c:\firewall.log -ErrorAction Inquire -Verbose</Path>
+          <Description>Add to Hosts file</Description>
+          <Order><%= order = 1 %></Order>
+          <Path>powershell.exe -Command "Add-Content \"c:\windows\system32\drivers\etc\hosts\" \"`n<%= URI.parse(repo_url).host %> dellasm\""</Path>
         </RunSynchronousCommand>
--->
+
         <%=
           if os.ntp_server
              ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
              command1 = "cmd /c w32tm /config /manualpeerlist:\"#{ntp_servers}\" /syncfromflags:MANUAL"
-             command2 = "cmd /c &quot;sc config w32time start= auto&quot;"
-             command3 = "powershell.exe -Command restart-Service w32time"
+             command2 = "cmd /c &quot;sc triggerinfo w32time start/networkon stop/networkoff&quot;"
+             command3 = "cmd /c &quot;sc config w32time start= auto&quot;"
+             command4 = "powershell.exe -Command restart-Service w32time"
              str = "<RunSynchronousCommand wcm:action=\"add\">
           <Description>NTP Server configuration</Description>
-          <Order>1</Order>
+          <Order>#{order += 1}</Order>
           <Path>#{command1}</Path>
         </RunSynchronousCommand>
-<RunSynchronousCommand wcm:action=\"add\">
-          <Description>Configure service w32time as Automatic</Description>
-          <Order>2</Order>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Configure w32time to trigger from netework instead of domain</Description>
+          <Order>#{order += 1}</Order>
           <Path>#{command2}</Path>
         </RunSynchronousCommand>
-<RunSynchronousCommand wcm:action=\"add\">
-          <Description>Start time configuration</Description>
-          <Order>3</Order>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Configure service w32time as Automatic</Description>
+          <Order>#{order += 1}</Order>
           <Path>#{command3}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Start time configuration</Description>
+          <Order>#{order += 1}</Order>
+          <Path>#{command4}</Path>
         </RunSynchronousCommand>"
           end
         %>
 
-<!-- adding puppet master server to hosts file -->
-        <RunSynchronousCommand wcm:action="add">
-          <Description>Add to Hosts file</Description>
-          <Order>4</Order>
-          <Path>powershell.exe -Command "Add-Content \"c:\windows\system32\drivers\etc\hosts\" \"`n<%= URI.parse(repo_url).host %> dellasm\""</Path>
-        </RunSynchronousCommand>
-
-<!-- Replace PUPPETSERVER with your puppet server -->
+        <!-- Replace PUPPETSERVER with your puppet server -->
         <RunSynchronousCommand wcm:action="add">
           <Description>Install Puppet Agent from razor server</Description>
-          <Order>5</Order>
+          <Order><%= order += 1 %></Order>
           <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=&quot;NetworkService&quot; </Path>
         </RunSynchronousCommand>
 
         <RunSynchronousCommand wcm:action="add">
          <Description>Updating registry to run puppet config timeout setup</Description>
-         <Order>6</Order>
+         <Order><%= order += 1 %></Order>
          <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set configtimeout 600 --section main &quot; /f</Path>
         </RunSynchronousCommand>
 
         <RunSynchronousCommand wcm:action="add">
          <Description>Configure service puppet as delayed Automatic</Description>
-         <Order>7</Order>
+         <Order><%= order += 1 %></Order>
          <Path>cmd /c &quot;sc config puppet start= delayed-auto&quot;</Path>
         </RunSynchronousCommand>
 
         <RunSynchronousCommand wcm:action="add">
           <Description>Set poll interval for puppet runs</Description>
-          <Order>8</Order>
+          <Order><%= order += 1 %></Order>
           <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set runinterval 5m --section main &quot; /f</Path>
         </RunSynchronousCommand>
       </RunSynchronous>

--- a/tasks/windows2008.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2008.task/hyper-v-unattended.xml.erb
@@ -95,20 +95,50 @@
  <!-- adding puppet master server to hosts file -->
       <RunSynchronousCommand wcm:action="add">
         <Description>Add to Hosts file</Description>
-        <Order>1</Order>
+        <Order><%= order = 1 %></Order>
         <Path>powershell.exe -Command "Add-Content \"c:\windows\system32\drivers\etc\hosts\" \"`n<%= URI.parse(repo_url).host %> dellasm\""</Path>
       </RunSynchronousCommand>
 
-<!-- Replace PUPPETSERVER with your puppet server -->
+        <%=
+          if os.ntp_server
+             ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
+             command1 = "cmd /c w32tm /config /manualpeerlist:\"#{ntp_servers}\" /syncfromflags:MANUAL"
+             command2 = "cmd /c &quot;sc triggerinfo w32time start/networkon stop/networkoff&quot;"
+             command3 = "cmd /c &quot;sc config w32time start= auto&quot;"
+             command4 = "powershell.exe -Command restart-Service w32time"
+             str = "<RunSynchronousCommand wcm:action=\"add\">
+          <Description>NTP Server configuration</Description>
+          <Order>#{order += 1}</Order>
+          <Path>#{command1}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Configure w32time to trigger from netework instead of domain</Description>
+          <Order>#{order += 1}</Order>
+          <Path>#{command2}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Configure service w32time as Automatic</Description>
+          <Order>#{order += 1}</Order>
+          <Path>#{command3}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Start time configuration</Description>
+          <Order>#{order += 1}</Order>
+          <Path>#{command4}</Path>
+        </RunSynchronousCommand>"
+          end
+        %>
+
+      <!-- Replace PUPPETSERVER with your puppet server -->
       <RunSynchronousCommand wcm:action="add">
         <Description>Install Puppet Agent from razor server</Description>
-        <Order>2</Order>
+        <Order><%= order += 1 %></Order>
         <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.3.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=Administrator PUPPET_AGENT_ACCOUNT_PASSWORD=&quot;<%= ASM::Cipher.decrypt_string(node.root_password) %>&quot;</Path>
       </RunSynchronousCommand>
 
       <RunSynchronousCommand wcm:action="add">
         <Description>Updating registry to run ASM script on every reboot</Description>
-        <Order>3</Order>
+        <Order><%= order += 1 %></Order>
         <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v ASMScript /t REG_SZ /d &quot;cmd /c c:\ASMPostInstall\ASMScript.cmd&quot; /f</Path>
       </RunSynchronousCommand>
     </RunSynchronous>

--- a/tasks/windows2012.task/default-unattended.xml.erb
+++ b/tasks/windows2012.task/default-unattended.xml.erb
@@ -100,67 +100,65 @@
     <%= render_template("windows_static_network") %>
     <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <RunSynchronous>
-<!-- commenting this out since this does not work yet -->
-<!--
+        <!-- adding puppet master server to hosts file -->
         <RunSynchronousCommand wcm:action="add">
-          <Description>Disable firewall</Description>
-          <Order>1</Order>
-          <Path>powershell.exe -ExecutionPolicy Bypass Set-NetFirewallProfile -Enabled False -LogFileName c:\firewall.log -ErrorAction Inquire -Verbose</Path>
+          <Description>Add to Hosts file</Description>
+          <Order><%= order = 1 %></Order>
+          <Path>powershell.exe -Command "Add-Content \"c:\windows\system32\drivers\etc\hosts\" \"`n<%= URI.parse(repo_url).host %> dellasm\""</Path>
         </RunSynchronousCommand>
--->
+
         <%=
           if os.ntp_server
              ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
              command1 = "cmd /c w32tm /config /manualpeerlist:\"#{ntp_servers}\" /syncfromflags:MANUAL"
-             command2 = "cmd /c &quot;sc config w32time start= auto&quot;"
-             command3 = "powershell.exe -Command restart-Service w32time"
+             command2 = "cmd /c &quot;sc triggerinfo w32time start/networkon stop/networkoff&quot;"
+             command3 = "cmd /c &quot;sc config w32time start= auto&quot;"
+             command4 = "powershell.exe -Command restart-Service w32time"
              str = "<RunSynchronousCommand wcm:action=\"add\">
           <Description>NTP Server configuration</Description>
-          <Order>1</Order>
+          <Order>#{order += 1}</Order>
           <Path>#{command1}</Path>
         </RunSynchronousCommand>
         <RunSynchronousCommand wcm:action=\"add\">
-          <Description>Configure service w32time as Automatic</Description>
-          <Order>2</Order>
+          <Description>Configure w32time to trigger from netework instead of domain</Description>
+          <Order>#{order += 1}</Order>
           <Path>#{command2}</Path>
         </RunSynchronousCommand>
         <RunSynchronousCommand wcm:action=\"add\">
-          <Description>Start time configuration</Description>
-          <Order>3</Order>
+          <Description>Configure service w32time as Automatic</Description>
+          <Order>#{order += 1}</Order>
           <Path>#{command3}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Start time configuration</Description>
+          <Order>#{order += 1}</Order>
+          <Path>#{command4}</Path>
         </RunSynchronousCommand>"
           end
         %>
 
-<!-- adding puppet master server to hosts file -->
-        <RunSynchronousCommand wcm:action="add">
-          <Description>Add to Hosts file</Description>
-          <Order>4</Order>
-          <Path>powershell.exe -Command "Add-Content \"c:\windows\system32\drivers\etc\hosts\" \"`n<%= URI.parse(repo_url).host %> dellasm\""</Path>
-        </RunSynchronousCommand>
-
 <!-- Replace PUPPETSERVER with your puppet server -->
         <RunSynchronousCommand wcm:action="add">
           <Description>Install Puppet Agent from razor server</Description>
-          <Order>5</Order>
+          <Order><%= order += 1 %></Order>
           <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=&quot;NetworkService&quot; </Path>
         </RunSynchronousCommand>
 
         <RunSynchronousCommand wcm:action="add">
           <Description>Updating registry to run ASM script on every reboot</Description>
-          <Order>6</Order>
+          <Order><%= order += 1 %></Order>
           <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set configtimeout 600 --section main &quot; /f</Path>
         </RunSynchronousCommand>
 
         <RunSynchronousCommand wcm:action="add">
            <Description>Configure service puppet as delayed Automatic</Description>
-           <Order>7</Order>
+           <Order><%= order += 1 %></Order>
            <Path>cmd /c &quot;sc config puppet start= delayed-auto&quot;</Path>
           </RunSynchronousCommand>
 
         <RunSynchronousCommand wcm:action="add">
           <Description>Set poll interval for puppet runs</Description>
-          <Order>8</Order>
+          <Order><%= order += 1 %></Order>
           <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set runinterval 5m --section main &quot; /f</Path>
         </RunSynchronousCommand>
       </RunSynchronous>

--- a/tasks/windows2012.task/hyper-v-unattended.xml.erb
+++ b/tasks/windows2012.task/hyper-v-unattended.xml.erb
@@ -91,56 +91,61 @@
     <%= render_template("windows_static_network") %>
     <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <RunSynchronous>
-
- <!-- adding puppet master server to hosts file -->
+      <!-- adding puppet master server to hosts file -->
       <RunSynchronousCommand wcm:action="add">
         <Description>Add to Hosts file</Description>
-        <Order>1</Order>
+        <Order><%= order = 1 %></Order>
         <Path>powershell.exe -Command "Add-Content \"c:\windows\system32\drivers\etc\hosts\" \"`n<%= URI.parse(repo_url).host %> dellasm\""</Path>
       </RunSynchronousCommand>
 
-<!-- Replace PUPPETSERVER with your puppet server -->
+        <%=
+          if os.ntp_server
+             ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
+             command1 = "cmd /c w32tm /config /manualpeerlist:\"#{ntp_servers}\" /syncfromflags:MANUAL"
+             command2 = "cmd /c &quot;sc triggerinfo w32time start/networkon stop/networkoff&quot;"
+             command3 = "cmd /c &quot;sc config w32time start= auto&quot;"
+             command4 = "powershell.exe -Command restart-Service w32time"
+             str = "<RunSynchronousCommand wcm:action=\"add\">
+          <Description>NTP Server configuration</Description>
+          <Order>#{order += 1}</Order>
+          <Path>#{command1}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Configure w32time to trigger from netework instead of domain</Description>
+          <Order>#{order += 1}</Order>
+          <Path>#{command2}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Configure service w32time as Automatic</Description>
+          <Order>#{order += 1}</Order>
+          <Path>#{command3}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action=\"add\">
+          <Description>Start time configuration</Description>
+          <Order>#{order += 1}</Order>
+          <Path>#{command4}</Path>
+        </RunSynchronousCommand>"
+          end
+        %>
+
+      <!-- Replace PUPPETSERVER with your puppet server -->
       <RunSynchronousCommand wcm:action="add">
         <Description>Install Puppet Agent from razor server</Description>
-        <Order>2</Order>
+        <Order><%= order += 1 %></Order>
         <Path>msiexec /i \\<%= URI.parse(repo_url).host %>\razor\puppet-agent\windows\puppet-3.6.2.msi /qn PUPPET_MASTER_SERVER=&quot;dellasm&quot; PUPPET_AGENT_CERTNAME=&quot;<%= node.policy.node_metadata['installer_options']['agent_certname'] %>&quot; PUPPET_AGENT_ACCOUNT_USER=&quot;NetworkService&quot; </Path>
       </RunSynchronousCommand>
 
       <RunSynchronousCommand wcm:action="add">
         <Description>Updating registry to run ASM script on every reboot</Description>
-        <Order>3</Order>
+        <Order><%= order += 1 %></Order>
         <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v ASMScript /t REG_SZ /d &quot;cmd /c c:\ASMPostInstall\ASMScript.cmd&quot; /f</Path>
       </RunSynchronousCommand>
 
        <RunSynchronousCommand wcm:action="add">
         <Description>Updating registry to run Puppet config script on every reboot</Description>
-        <Order>4</Order>
+        <Order><%= order += 1 %></Order>
         <Path>REG.EXE ADD HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v PuppetCmd /t REG_SZ /d &quot;cmd /c c:\Progra~2\Puppet~1\Puppet\bin\puppet.bat config set configtimeout 600 --section main &quot; /f</Path>
       </RunSynchronousCommand>
-
-      <%=
-          if os.ntp_server
-             ntp_servers = os.ntp_server.delete(" ").split(",").join(" ")
-             command1 = "cmd /c w32tm /config /manualpeerlist:\"#{ntp_servers}\" /syncfromflags:MANUAL"
-             command2 = "cmd /c &quot;sc config w32time start= delayed-auto&quot;"
-             command3 = "powershell.exe -Command restart-Service w32time"
-             str = "<RunSynchronousCommand wcm:action=\"add\">
-          <Description>NTP Server configuration</Description>
-          <Order>5</Order>
-          <Path>#{command1}</Path>
-        </RunSynchronousCommand>
-        <RunSynchronousCommand wcm:action=\"add\">
-          <Description>Configure service w32time as Delayed Automatic</Description>
-          <Order>6</Order>
-          <Path>#{command2}</Path>
-        </RunSynchronousCommand>
-        <RunSynchronousCommand wcm:action=\"add\">
-          <Description>Start time configuration</Description>
-          <Order>7</Order>
-          <Path>#{command3}</Path>
-        </RunSynchronousCommand>"
-          end
-        %>
     </RunSynchronous>
     </component>
   </settings>


### PR DESCRIPTION
By default the Windows w32time (NTP) service if set to Auto start is
actually set to Auto (triggered). And the default trigger is when the
domain service starts. Therefore in cases where the server is not
joined to a domain the service never starts up after reboot. This
behavior and workaround is document in the Microsoft support article
[Windows Time service doesn't start automatically on a workgroup
computer that's running Windows 7 or Windows Server 2008 R2][1].

Additionally the timezone setting in the Windows unattended.xml file
seems to be applied after the `<RunSynchronous>` commands are
executed. We use the `<RunSycnhronous>` commands to configure
NTP. Therefore NTP starts (and presumably sets the correct time) and
then the timezone is changed which changes the system time. Since most
of the unattended.xml files set Central timezone and the default
appears to be Pacific, this results in the server time being two hours
behind where it should be. After restart of the server NTP is not
started (if the domain service is not configured) resulting in an
incorrect time forever after.

This change follows one of the recommendations in the linked article
to change the trigger to be when the network starts or stops rather
than when the domain service starts or stops. Therefore NTP should
start after reboot and correct the time.

Additionally it appears NTP settings were left out entirely of the
Windows 2008 Hyper-V unattend.xml; this commit adds them in.

Finally, `dellasm` may be set as one of the NTP servers, so its
definition in the hosts file is moved to happen before NTP is set.

[1]: https://support.microsoft.com/en-in/help/2385818/windows-time-service-doesn-t-start-automatically-on-a-workgroup-computer-that-s-running-windows-7-or-windows-server-2008-r2