### PR TITLE
ASM-8323 Using dellasm as ntp server failing

### DIFF
--- a/tasks/suse11.task/autoyast.erb
+++ b/tasks/suse11.task/autoyast.erb
@@ -455,7 +455,7 @@ S1
 <%= ntpserver unless ntpserver.empty? %>
     </peers>
     <start_at_boot config:type="boolean">true</start_at_boot>
-    <start_in_chroot config:type="boolean">true</start_in_chroot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
   </ntp-client>
   <scripts>
     <chroot-scripts config:type="list">

--- a/tasks/suse11.task/post_install.erb
+++ b/tasks/suse11.task/post_install.erb
@@ -16,8 +16,8 @@ rm -rf /var/lib/puppet/ssl
 #add the puppet master host entry in /etc/hosts
 echo "<%= URI.parse(repo_url).host %> dellasm" >> /etc/hosts
 
-#ensure ntp is running
-/etc/init.d/ntp start
+#ensure ntp is running (It should already have been started in aytoyast but needs a restart to resolve dellasm hostname)
+/etc/init.d/ntp restart
 
 #Install the puppet agent
 mkdir /tmp/mnt

--- a/tasks/suse12.task/autoyast.erb
+++ b/tasks/suse12.task/autoyast.erb
@@ -375,7 +375,7 @@
       </peer>
     </peers>
     <start_at_boot config:type="boolean">true</start_at_boot>
-    <start_in_chroot config:type="boolean">true</start_in_chroot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
   </ntp-client>
   <scripts>
     <chroot-scripts config:type="list">

--- a/tasks/suse12.task/post_install.erb
+++ b/tasks/suse12.task/post_install.erb
@@ -29,6 +29,9 @@ cat /etc/puppet/puppet.conf
 chkconfig puppet on
 service puppet start
 
+#ensure ntp is running (It should already have been started in aytoyast but needs a restart to resolve dellasm hostname)
+/etc/init.d/ntp restart
+
 cat <<EOF > /etc/motd
 Installed by Razor using <%= task.label %> - <%= task.description %>
 Repo: <%= repo_url %>


### PR DESCRIPTION
Because ntp is setup and started in the autoyast section, it originally
cannot resolve the dellasm hostname.  Need to restart ntp service
in the postinstall to ensure it can resolve dellasm

Also, ntpq -p returns: **No association ID's returned** when it is running in chroot jails
due to lack of needed files