### PR TITLE
ASM-9640 updated rpm installation with additional force opt

### DIFF
--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -39,7 +39,7 @@ elif rpm -q libselinux-2.0.94-5.8.el6.x86_64; then
   rpm -ivh `ls /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/*.rpm | grep -v libselinux-ruby-2.0.94-5.3.el6_4.1.x86_64.rpm`
 elif rpm -q libselinux-2.5-6.el7.x86_64; then
   # RHEL 7.3 has libselinux-2.5-6 installed and requires different versions of packages
-  rpm -ivh --replacepkgs /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/rhel7_3/*.rpm
+  rpm -ivh --replacefiles --replacepkgs /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/rhel7_3/*.rpm
 elif rpm -q libselinux-ruby; then
   # HACK: RHEL 7.2 already has libselinux-ruby installed. Skip in that case.
   rpm -ivh `ls /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/*.rpm | grep -v libselinux-ruby`


### PR DESCRIPTION
For certain RHEL 7.3 and CentOS 7.3 ISO's, the "--replacepkgs" opt
is not enough. Certain files may be in conflict. In such a case,
we also need "--replacefiles" opt.