### PR TITLE
ASM-9663 add network-online dependency to puppet.service

### DIFF
--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -128,8 +128,28 @@ echo ========================================================================
 
 #start and enable the puppet agent
 <% if task.os_version == '7' %>
-systemctl enable puppet.service
-systemctl start puppet.service
+# RHEL7 distro comes with systemd service file, but the default dependency description does not ensure puppet to wait for network service
+# The following lines add required Service Unit segment(s) and/or target(s)
+SVCFILE=/usr/lib/systemd/system/puppet.service
+
+# Ensure network-online.target is in Requires=
+if ! grep Requires "$SVCFILE" > /dev/null; then
+  sed -i '/^After=/ i Requires=network-online.target' "$SVCFILE"
+fi
+if ! grep Requires "$SVCFILE" | grep network-online.target > /dev/null; then
+  echo "Failed to set Requires=network-online.target in '$SVCFILE'"
+  exit 1
+fi
+
+# Ensure network-online.target is in After=
+if ! grep After "$SVCFILE" | grep network-online.target > /dev/null; then
+    sed -i "/After=/ s/$/ network-online.target/" $SVCFILE
+fi
+if ! grep After "$SVCFILE" | grep network-online.target > /dev/null; then
+  echo "Failed to set After=network-online.target in '$SVCFILE'"
+  exit 2
+fi
+
 
 # RHEL7 distro has a puppet bug that does not remove the lock file successfully even when there's no puppet process running.
 # The following crontab task should remove it during the reboot only if there is no running puppet process.
@@ -138,7 +158,7 @@ cat > /etc/systemd/system/puppetclean.service << EOF
 Description=Clean up the puppet agent lock file without puppet process running
 Wants=basic.target
 After=basic.target
-Before=pupetagent.service
+Before=puppet.service
 
 [Service]
 ExecStart=/bin/find /var/lib/puppet/state/agent_catalog_run.lock -size 0 -delete
@@ -147,9 +167,14 @@ ExecStart=/bin/find /var/lib/puppet/state/agent_catalog_run.lock -size 0 -delete
 WantedBy=multi-user.target
 EOF
 
+chmod 644 /usr/lib/systemd/system/puppet.service
 chmod 644 /etc/systemd/system/puppetclean.service
+
 systemctl enable puppetclean
 systemctl start puppetclean
+
+systemctl enable puppet.service
+systemctl start puppet.service
 <% else %>
 chkconfig puppet on
 service puppet start


### PR DESCRIPTION
For RHEL/CentOS 7.3, there is a known bug that causes the puppet
service to run before the network is fully up. For most modules,
this won't be a real issue since puppet agent will retry again
later. However, this causes a problem for network module since
this module will try to rewrite the configurations and restart
the service, which results in misconfigured network service and
locked down service status for both network and puppet.

To fix this issue, the razor post_install script will now create
the custom puppet.service systemd script with network-online.target
for Requires and After sections in the service unit descriptor.