### PR TITLE
ASM-9853 deploy CentOS 7.4 VM

### DIFF
--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -40,6 +40,9 @@ elif rpm -q libselinux-2.0.94-5.8.el6.x86_64; then
 elif rpm -q libselinux-2.5-6.el7.x86_64; then
   # RHEL 7.3 has libselinux-2.5-6 installed and requires different versions of packages
   rpm -ivh --replacefiles --replacepkgs /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/rhel7_3/*.rpm
+elif rpm -q libselinux-2.5-11.el7.x86_64; then
+  # RHEL 7.4 has libselinux-2.5-11 installed and requires different versions of packages
+  rpm -ivh /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/rhel7_4/*.rpm
 elif rpm -q libselinux-ruby; then
   # HACK: RHEL 7.2 already has libselinux-ruby installed. Skip in that case.
   rpm -ivh `ls /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/*.rpm | grep -v libselinux-ruby`


### PR DESCRIPTION
This is a small change in the razor post_install script to support
puppet installation on CentOS 7.4 VM.