### PR TITLE
Lud 77 - A: puppet configuration file location fix

### DIFF
--- a/tasks/common/puppet_conf.erb
+++ b/tasks/common/puppet_conf.erb
@@ -1,5 +1,5 @@
 #update puppet.conf file
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
     server = dellasm
     logdir = /var/log/puppet

--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -83,7 +83,7 @@ fi
 <%= render_template("puppet_conf") %>
 
 # Nagios NRPE configuration, used only for C* series machines
-if [[ "$(/usr/bin/facter productname)" =~ ^PowerEdge\ C62[0-9]+ ]]; then
+if [[ "$(/opt/puppetlabs/bin/facter productname)" =~ ^PowerEdge\ C62[0-9]+ ]]; then
   /bin/sed -i 's:allowed_hosts=127.0.0.1:allowed_hosts=dellasm,127.0.0.1:' /etc/nagios/nrpe.cfg
   /bin/sed -i '/^command\[/ s:^:#:' /etc/nagios/nrpe.cfg
 
@@ -125,8 +125,8 @@ __ASM_SELINUX__
 fi
 
 # For debugging, just in case, dump out the modified confirmation file.
-echo ====================[ /etc/puppet/puppet.conf ]=========================
-cat /etc/puppet/puppet.conf
+echo ====================[ /etc/puppetlabs/puppet/puppet.conf ]=========================
+cat /etc/puppetlabs/puppet/puppet.conf
 echo ========================================================================
 
 #start and enable the puppet agent

--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -40,6 +40,9 @@ elif rpm -q libselinux-2.0.94-5.8.el6.x86_64; then
 elif rpm -q libselinux-2.5-6.el7.x86_64; then
   # RHEL 7.3 has libselinux-2.5-6 installed and requires different versions of packages
   rpm -ivh --replacefiles --replacepkgs /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/rhel7_3/*.rpm
+elif rpm -q libselinux-2.5-11.el7.x86_64; then
+  # RHEL 7.4 has libselinux-2.5-11 installed and requires different versions of packages
+  rpm -ivh /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/rhel7_4/*.rpm
 elif rpm -q libselinux-ruby; then
   # HACK: RHEL 7.2 already has libselinux-ruby installed. Skip in that case.
   rpm -ivh `ls /tmp/mnt/puppet-agent/rhel<%= task.os_version %>/x86_64/*.rpm | grep -v libselinux-ruby`


### PR DESCRIPTION
ASM-77(A) fix for puppet configuration template
    
    This commit includes fix for the puppet configuration template,
    which is used by the razor post_install script. There are also
    other minor fixes in the post_install script itself to let
    RHEL deployments to work until puppet.broker is implemented to
    meet the overall requirement of this ticket.
