### PR TITLE
CentOS 7.4 ScaleIO VM RPM dependencies

### DIFF
--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -84,6 +84,11 @@ ntp
 smartmontools
 usbutils
 policycoreutils-python
+mutt
+wget
+numactl
+java-1.8.0-openjdk
+python-cryptography
 
 %end
 


### PR DESCRIPTION
Additional RPMs are required for ScaleIO SVM puppet modules configuraiton on CentOS 7.4