### PR TITLE
Point to razor OS repo URL as default yum repo

### DIFF
--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -84,6 +84,7 @@ ntp
 smartmontools
 usbutils
 policycoreutils-python
+yum-utils
 
 %end
 

--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -18,6 +18,22 @@ fi
 # careful though, since this file is also used by the CentOS installer, for
 # which there is no RHN registration
 
+# Disable base and updates repos as node may not have internet access
+
+yum-config-manager --disable base
+yum-config-manager --disable updates
+yum-config-manager --disable extras
+
+# Add base repo from iso
+cat > /etc/yum.repos.d/razor-internal.repo << EOF
+[razor-internal]
+name=Internal Razor OS Repository
+baseurl=<%= repo_url %>
+gpgcheck=1
+gpgkey=<%= repo_url %>/RPM-GPG-KEY-CentOS-\$releasever
+enabled=True
+EOF
+
 <%= render_template("os_complete") %>
 
 # We are done


### PR DESCRIPTION
The CentOS ISO contains both the default RPM packages and GPG keys and
is available via razor's HTTP repo_url. This change sets that up as
the only enabled yum repository on a default CentOS install. This will
allow "yum install" commands to work out of the box even if the node
has no external internet access. This will make it easier to customize
the OS for different appliaction flows.