### PR TITLE
LUD-547 Use dellasm hostname for razor-internal EL repo

### DIFF
--- a/brokers/ludwig-puppet.broker/install.erb
+++ b/brokers/ludwig-puppet.broker/install.erb
@@ -25,11 +25,6 @@ if [ "$release" ==  "" ]; then
     release="$(echo $RELEASE_DATA_LLecho $RELEASE_DATA_LL | cut -f2 | cut -d. -f1 | awk '{ print $4  }')"
 fi
 
-#add the puppet master host entry in /etc/hosts
-if ! grep -q <%= broker[:server] %> /etc/hosts; then
-echo "<%= URI.parse(stage_done_url).host %> <%= broker[:server] %>" >> /etc/hosts
-fi
-
 ### Enable ASM / ASM Puppet repo and install puppet-agent
 rpm -Uvh http://<%= broker[:server] %>:8080/svc/repo/puppet-agent/rhel${release}/x86_64/puppet-release-1.0.0-1.el${release}.noarch.rpm
 sed -i -e "s,http://yum.puppetlabs.com/puppet/el/$release/\$basearch,http://<%= broker[:server] %>:8080/svc/repo/puppet-agent/rhel\$releasever/\$basearch," /etc/yum.repos.d/puppet.repo

--- a/tasks/redhat.task/post_install.erb
+++ b/tasks/redhat.task/post_install.erb
@@ -18,6 +18,21 @@ fi
 # careful though, since this file is also used by the CentOS installer, for
 # which there is no RHN registration
 
+<%
+require "uri"
+
+parsed = URI.parse(repo_url)
+
+razor_ip = parsed.host
+
+parsed.host = "dellasm"
+
+iso_repo_url = parsed.to_s
+%>
+
+# add the dellasm host entry to /etc/hosts
+echo "<%= razor_ip %> dellasm" >> /etc/hosts
+
 # Disable base and updates repos as node may not have internet access
 
 yum-config-manager --disable base
@@ -28,9 +43,9 @@ yum-config-manager --disable extras
 cat > /etc/yum.repos.d/razor-internal.repo << EOF
 [razor-internal]
 name=Internal Razor OS Repository
-baseurl=<%= repo_url %>
+baseurl=<%= iso_repo_url %>
 gpgcheck=1
-gpgkey=<%= repo_url %>/RPM-GPG-KEY-CentOS-\$releasever
+gpgkey=<%= iso_repo_url %>/RPM-GPG-KEY-CentOS-\$releasever
 enabled=True
 EOF
 


### PR DESCRIPTION
Previously razor's `repo_url` was used to create a yum repository
pointing to the RHEL/CentOS repository files included on the
ISO. However that URL typically has an internal PXE IP which may not
be accessible by the node after the PXE network is removed.

Instead define and use an `/etc/hosts` file entry that points to the
internal PXE IP. It will be updated later on if needed by puppet
configuration when the PXE network is removed. The repository URL can
then use the `hosts` file entry instead of the IP directly.