### PR TITLE
VXFM-2609 ASMDeployer - Add support for OS credentials

### DIFF
--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -10,7 +10,7 @@ keyboard us
 rootpw --iscrypted <%=
     require 'asm/cipher'
     require 'unix_crypt'
-    asm_decrypted_password = ASM::Cipher.decrypt_string(node.root_password)
+    asm_decrypted_password = ASM::Cipher.decrypt_credential(node.root_password)['password']
     UnixCrypt::SHA512.build(asm_decrypted_password)
 %>
 <%

--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -7,7 +7,7 @@ rootpw --iscrypted <%=
   else
     require 'asm/cipher'
     require 'unix_crypt'
-    asm_decrypted_password = ASM::Cipher.decrypt_string(node.root_password)
+    asm_decrypted_password = ASM::Cipher.decrypt_credential(node.root_password)['password']
     # @todo danielp 2013-11-07: if ESXi supports a stronger algorithm, we
     # should probably upgrade to using it in preference to MD5.  SHA512 is
     # current state-of-the-art practice, elsewhere.


### PR DESCRIPTION
Updated kickstarts to use os_credential instead of admin password.

PRs to be merged with:
https://github.com/dell-asm/asm-deployer/pull/2511
https://github.com/dell-asm/asm-core/pull/3975
https://github.com/dell-asm/asm/pull/369