### PR TITLE
VXFM-3518 Run ntpdate prior to installing puppet

### DIFF
--- a/brokers/puppet.broker/install.erb
+++ b/brokers/puppet.broker/install.erb
@@ -37,7 +37,7 @@ else
 fi
 
 # Synchronize time with ntpdate server before registering with the server.
-ntpdate_server=<% broker[:ntpdate_server] || '' %>
+ntpdate_server=<%= broker[:ntpdate_server] || '' %>
 if [ -z $ntpdate_server ]; then
     : # skipping ntpdate since `ntpdate_server` is not set
 elif cmd ntpdate; then


### PR DESCRIPTION
There was code in the puppet broker to run ntpdate against the broker
`ntpdate_server` but it wasn't working due to using wrong ERB syntax.