### PR TITLE
VXFM-3514 Partitions on drives with HBA330 causes adding them to VxFlex OS to fail

### DIFF
--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -105,6 +105,27 @@ yum-utils
   echo "ignoredisk --only-use=$FIRST_PERC_VOL" >> /tmp/ignoredisk
   echo "clearpart --all --initlabel"  >> /tmp/ignoredisk
   echo "autopart" >> /tmp/ignoredisk
+
+<% if options["target_boot_device"] =~ /LOCAL_FLASH_STORAGE/%>
+  # Clear existing partitions on all disks
+  system_partition=`fdisk -l | egrep '/dev/[a-zA-Z]+[0-9]  *' | sed -E -e 's/[[:blank:]]+/\n/g' | egrep '[a-zA-Z]+[0-9]' | cut -f3 -d'/'`
+  system_disk=`echo $system_partition | sed -E -e 's/[0-9]+//g'`
+  disks=`lsblk -n -p -fs | grep -v $system_partition  | grep -v $system_disk | grep -v sr0`
+  cat /proc/partitions > /tmp/partitions
+  partitions=`cat /tmp/partitions | sed -E -e 's/[[:blank:]]+/\n/g' | egrep '[a-zA-Z]+[0-9]$' | grep -v "sr0" | grep -v $system_partition`
+  if [ $? -eq 0 ]; then
+    for part in $partitions; do
+      echo "Clearing existing partition $part"
+      hdparm -z /dev/$part 2>/dev/null
+    done
+  fi
+
+  for disk in $disks; do
+    echo "Cleaning Disk: $disk"
+    dd if=/dev/zero of=$disk bs=1M count=50 status=progress
+  done
+<% end %>
+
 %end
 
 %post --log=/var/log/razor.log


### PR DESCRIPTION
Clear all the partitions from the server before initiating the OS installation. This will take care of all stale partitions from previous installation