### PR TITLE
VXFM-4653 Backend ASMDeployer changes to support FlexOS 3.0 compression

### DIFF
--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -84,6 +84,7 @@ smartmontools
 usbutils
 policycoreutils-python
 yum-utils
+iptables-services
 
 %end
 


### PR DESCRIPTION
Including Iptables.services packages to be included during RHEL installation. This is required to allow VxOS ports to be opened for MDM and SDS communication.