### PR TITLE
VXFM-6181 Partitions not cleared from storage-only disk

### DIFF
--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -124,7 +124,7 @@ echo Kickstart post
     done
   fi
 
-  FIRST_PERC_VOL=`cat /root/first_perc_vol.txt`
+  FIRST_PERC_VOL=$(ls -1 /dev/disk/by-path/pci-*-ata* | sort -t- -k 4 | head -1)
   disks=`ls -1 /dev/disk/by-path/pci-* | grep -v $FIRST_PERC_VOL | grep -v part`
   for disk in $disks; do
     echo "Cleaning Disk: $disk"


### PR DESCRIPTION
For storage only servers, disk cleanup code was working after last refactoring where we tried to reuse a file created in "pre" installation stage in post-installation stage. Looks like, the file created in the pre-installation stage is deleted and it is no longer available in the post-installation stage